### PR TITLE
Update type definitions to include null case

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
 declare module "locale-currency" {
-  export function getCurrency(locale: string): string;
+  export function getCurrency(locale: string): string | null;
   export function getLocales(currencyCode: string): string[];
 }


### PR DESCRIPTION
The function `getCurrency` returns null if no currency matches the given locale, and the typescript definitions should reflect this.