### PR TITLE
fix(zambian-kwacha): change currency code 'ZMK' to 'ZMW'

### DIFF
--- a/map.js
+++ b/map.js
@@ -246,7 +246,7 @@ WS: 'WST',
 YE: 'YER',
 YT: 'EUR',
 ZA: 'ZAR',
-ZM: 'ZMK',
+ZM: 'ZMW',
 ZW: 'ZWL'
 };
 


### PR DESCRIPTION
This updates the currency code for the Zambian Kwacha to the new 'ZMW' currency code, which has been in use since 2012.

[Source](https://en.wikipedia.org/wiki/Zambian_kwacha)